### PR TITLE
Added FLOX_SHELL environment variable

### DIFF
--- a/cli/flox/src/commands/environment.rs
+++ b/cli/flox/src/commands/environment.rs
@@ -414,7 +414,7 @@ impl ShellType {
     ///
     /// [1]: <https://github.com/flox/flox/blob/668a80a40ba19d50f8ca304ff351f4b27a886e21/flox-bash/lib/utils.sh#L1432>
     fn detect() -> Result<Self> {
-        let shell = env::var("SHELL").context("SHELL must be set")?;
+        let shell = env::var("FLOX_SHELL").unwrap_or(env::var("SHELL").context("SHELL must be set")?);
         let shell = Path::new(&shell);
         let shell = Self::try_from(shell)?;
         Ok(shell)


### PR DESCRIPTION
* Added FLOX_SHELL so the end-user can control which shell `flox activate` launches. This allows end-users who don't use `zsh` or `bash` to call `flox activate` without having to first launch a supported shell.

## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->


<!-- Many thanks! -->
